### PR TITLE
AGR-2528 elasticsearch dockerhub => ECR code-changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,31 @@
+REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+
+registry-docker-login:
+ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
+	@$(eval DOCKER_LOGIN_CMD=aws)
+ifneq (${AWS_PROFILE},)
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
+endif
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} ecr get-login-password | docker login -u AWS --password-stdin https://${REG})
+	${DOCKER_LOGIN_CMD}
+endif
+
 all:
-	docker build --no-cache -t agrdocker/agr_elasticsearch_env .
+	docker build --no-cache -t ${REG}/agr_elasticsearch_env .
 
-push:
-	docker push agrdocker/agr_elasticsearch_env
+push: registry-docker-login
+	docker push ${REG}/agr_elasticsearch_env
 
-pull:
-	docker pull agrdocker/agr_elasticsearch_env
+pull: registry-docker-login
+	docker pull ${REG}/agr_elasticsearch_env
 
 bash:
-	docker run -t -i agrdocker/agr_elasticsearch_env bash
+	docker run -t -i ${REG}/agr_elasticsearch_env bash
 
 run: docker-run
 
 docker-run:
-	docker run -p 9200:9200 -p 9300:9300 -e "http.host=0.0.0.0" -e "transport.host=0.0.0.0" -e "xpack.security.enabled=false" agrdocker/agr_elasticsearch_env
+	docker run -p 9200:9200 -p 9300:9300 -e "http.host=0.0.0.0" -e "transport.host=0.0.0.0" -e "xpack.security.enabled=false" ${REG}/agr_elasticsearch_env
 
 docker-pull-data:
 	docker pull agrdocker/agr_es_data_image

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,3 @@ run: docker-run
 
 docker-run:
 	docker run -p 9200:9200 -p 9300:9300 -e "http.host=0.0.0.0" -e "transport.host=0.0.0.0" -e "xpack.security.enabled=false" ${REG}/agr_elasticsearch_env
-
-docker-pull-data:
-	docker pull agrdocker/agr_es_data_image
-
-docker-run-data:
-	docker run -p 9200:9200 -p 9300:9300 -e "http.host=0.0.0.0" -e "transport.host=0.0.0.0" -e "xpack.security.enabled=false" agrdocker/agr_es_data_image


### PR DESCRIPTION
Makefile updates done to move away from dockerhub and into ECR as our docker image registry (analogous to alliance-genome/agr_ansible_devops#15) + deprecated `agr_es_data_image` image usage removal.